### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,6 @@ Client library to interact with Universal Core's `unicore.comments`
     :target: https://coveralls.io/r/universalcore/unicore.comments.client?branch=develop
     :alt: Code Coverage
 
-.. image:: https://pypip.in/version/unicore.comments.client/badge.svg
+.. image:: https://img.shields.io/pypi/v/unicore.comments.client.svg
     :target: https://pypi.python.org/pypi/unicore.comments.client
     :alt: Pypi Package


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20unicore-comments-client))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `unicore-comments-client`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.